### PR TITLE
search and replace (i) fixes (ii) new implementations (iii) patches

### DIFF
--- a/web/modules/custom/search_and_replace/search_and_replace.module
+++ b/web/modules/custom/search_and_replace/search_and_replace.module
@@ -11,7 +11,7 @@ use Drupal\search_and_replace\SarEntity;
 function search_and_replace_local_tasks_alter(&$local_tasks) {
   return \Drupal::service('class_resolver')
     ->getInstanceFromDefinition(SarEntity::class)
-    ->localTastAlter($local_tasks);
+    ->localTaskAlter($local_tasks);
 }
 
 /**
@@ -21,6 +21,25 @@ function search_and_replace_form_alter(&$form, FormStateInterface $form_state, $
   /*return \Drupal::service('class_resolver')
     ->getInstanceFromDefinition(SarForm::class)
     ->formAlter($form, $form_state, $form_id);*/
+}
+function search_and_replace_form_scanner_admin_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
+  //hardcoded disabled entity_types and fields
+  $forbidden_entity_types = ['paragraph'];
+  $forbidden_fields = ['field_descripcion'];
+  foreach ($form['enabled_content_types']['#options'] as $k => $v){
+    $entity = explode(":",$k);
+    if (in_array($entity[0], $forbidden_entity_types)){
+      unset($form['enabled_content_types']['#options'][$k]);
+    }
+  }
+  foreach ($form['fields_of_selected_content_type']['#options'] as $k => $v){
+    $entity = explode(":",$k);
+    if (in_array($entity[0], $forbidden_entity_types) OR in_array($entity[2],$forbidden_fields)){
+      unset($form['fields_of_selected_content_type']['#options'][$k]);
+    }
+  }
+}
+function search_and_replace_form_scanner_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 }
 
 /**

--- a/web/modules/custom/search_and_replace/search_and_replace.module
+++ b/web/modules/custom/search_and_replace/search_and_replace.module
@@ -25,7 +25,7 @@ function search_and_replace_form_alter(&$form, FormStateInterface $form_state, $
 function search_and_replace_form_scanner_admin_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
   //hardcoded disabled entity_types and fields
   $forbidden_entity_types = ['paragraph'];
-  $forbidden_fields = ['field_descripcion'];
+  $forbidden_fields = ['moderation_state'];
   foreach ($form['enabled_content_types']['#options'] as $k => $v){
     $entity = explode(":",$k);
     if (in_array($entity[0], $forbidden_entity_types)){

--- a/web/modules/custom/search_and_replace/src/Form/SarScannerConfirmForm.php
+++ b/web/modules/custom/search_and_replace/src/Form/SarScannerConfirmForm.php
@@ -7,13 +7,21 @@ use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\scanner\Form\ScannerConfirmForm;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Confirmation Form operations messages.
+ */
 class SarScannerConfirmForm extends ScannerConfirmForm {
 
   /**
+   * The Private temporary storage factory.
+   *
    * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
   private $tempStore;
 
+  /**
+   * {@inheritdoc}
+   */
   public function __construct(PrivateTempStoreFactory $tempStore) {
     parent::__construct($tempStore);
     $this->tempStore = $tempStore;
@@ -28,15 +36,27 @@ class SarScannerConfirmForm extends ScannerConfirmForm {
     );
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $build = parent::buildForm($form, $form_state);
 
-
     $scannerStore = $this->tempStore->get('scanner');
-    foreach (['search', 'replace', 'mode', 'wholeword', 'regex', 'preceded', 'followed', 'published', 'language'] as $value) {
+    $operations = [
+      'search',
+      'replace',
+      'mode',
+      'wholeword',
+      'regex',
+      'preceded',
+      'followed',
+      'published',
+      'language',
+    ];
+    foreach ($operations as $value) {
       $values[$value] = $scannerStore->get($value);
     }
-
     return $build;
   }
 

--- a/web/modules/custom/search_and_replace/src/Routing/SarRouteSubscriber.php
+++ b/web/modules/custom/search_and_replace/src/Routing/SarRouteSubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\search_and_replace\Routing;
 
-
 use Drupal\Core\Routing\RouteSubscriberBase;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -22,4 +21,5 @@ class SarRouteSubscriber extends RouteSubscriberBase {
       $route->setDefault('_form', '\Drupal\search_and_replace\Form\SarScannerConfirmForm');
     }
   }
+
 }

--- a/web/modules/custom/search_and_replace/src/SarEntity.php
+++ b/web/modules/custom/search_and_replace/src/SarEntity.php
@@ -16,8 +16,8 @@ class SarEntity {
    *
    * @see \hook_local_tasks_alter()
    */
-  public function localTastAlter(&$local_tasks) {
-    $local_tasks['scanner.admin_content']['title'] = strtoupper($this->t('Search and Replace'));
+  public function localTaskAlter(&$local_tasks) {
+    $local_tasks['scanner.admin_content']['title'] = $this->t('Search and Replace');
     $local_tasks['scanner.admin']['title'] = $this->t('Search');
   }
 

--- a/web/modules/custom/search_and_replace/src/SarForm.php
+++ b/web/modules/custom/search_and_replace/src/SarForm.php
@@ -2,13 +2,15 @@
 
 namespace Drupal\search_and_replace;
 
-use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * Alter Form for performing search.
+ */
 class SarForm implements ContainerInjectionInterface {
 
   use StringTranslationTrait;
@@ -20,6 +22,9 @@ class SarForm implements ContainerInjectionInterface {
    */
   protected $entityTypeBundleInfo;
 
+  /**
+   * {@inheritdoc}
+   */
   public function __construct(EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     $this->entityTypeBundleInfo = $entity_type_bundle_info;
   }
@@ -45,23 +50,6 @@ class SarForm implements ContainerInjectionInterface {
 
     $form['replace']['#weight'] = 99;
     $form['submit_replace']['#weight'] = 100;
-
-    /*$form['options']['bundles'] = [
-      '#type' => 'checkboxes',
-      '#title' => $this->t('Bundles'),
-      '#options' => $this->getAvailableEntityTypes(),
-      '#weight' => -2,
-      '#description' => $this->t('If none selected, all bundles will be used in search.'),
-    ];
-
-    $form['options']['version'] = [
-      '#type' => 'radios',
-      '#title' => $this->t('Bundles'),
-      '#options' => [0 => $this->t('Published'), 1 => $this->t('Current Draft')],
-      '#weight' => -1,
-      '#default_value' => 0,
-      '#description' => $this->t('Select the versions of the nodes on which you want to perform the search.'),
-    ];*/
 
     unset($form['options']['published']);
 


### PR DESCRIPTION
(i) fix selection logic in search and replace form
(ii) replace only works on selected elements
(iii) logic to disable entity types (paragraphs) and fields (moderation_state) causing scanner-1.x-dev to fail 
